### PR TITLE
Add ruff-format hook to pre-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ The "pre-commit Snippets" extension includes snippets for a variety of
 pre-commit hooks, including:
 
 <!-- markdownlint-disable MD013 -->
-|                                                              |                                                                       |                                                                |                                                                       |
-| :----------------------------------------------------------- | :-------------------------------------------------------------------- | :------------------------------------------------------------- | :-------------------------------------------------------------------- |
-| [ansible-lint](https://github.com/ansible/ansible-lint)      | [bandit](https://github.com/PyCQA/bandit)                             | [black](https://github.com/psf/black)                          | [black-jupyter](https://github.com/psf/black)                         |
-| [codespell](https://github.com/codespell-project/codespell)  | [config-files](https://github.com/pre-commit/pre-commit-hooks)        | [css](https://github.com/pre-commit/mirrors-csslint)           | [eslint](https://github.com/pre-commit/mirrors-eslint)                |
-| [flake8](https://github.com/pycqa/flake8)                    | [hook](https://github.com/pre-commit/pre-commit-hooks)                | [isort](https://github.com/pycqa/isort)                        | [markdownlint](https://github.com/markdownlint/markdownlint)          |
-| [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) | [mypy](https://github.com/pre-commit/mirrors-mypy)                    | [no-commit-to-branch](https://github.com/pre-commit/pre-commit-hooks) | [prettier](https://github.com/pre-commit/mirrors-prettier)            |
-| [pygrep-hooks](https://github.com/pre-commit/pygrep-hooks)    | [pyupgrade](https://github.com/asottile/pyupgrade)                    | [ruff](https://github.com/astral-sh/ruff-pre-commit)           | [shellcheck](https://github.com/shellcheck-py/shellcheck-py)          |
-| [yamllint](https://github.com/adrienverge/yamllint.git)      |                                                                       |                                                                |                                                                       |
+
+|                                                                       |                                                                |                                                                       |                                                              |
+| :-------------------------------------------------------------------- | :------------------------------------------------------------- | :-------------------------------------------------------------------- | :----------------------------------------------------------- |
+| [ansible-lint](https://github.com/ansible/ansible-lint)               | [bandit](https://github.com/PyCQA/bandit)                      | [black](https://github.com/psf/black)                                 | [black-jupyter](https://github.com/psf/black)                |
+| [codespell](https://github.com/codespell-project/codespell)           | [config-files](https://github.com/pre-commit/pre-commit-hooks) | [css](https://github.com/pre-commit/mirrors-csslint)                  | [eslint](https://github.com/pre-commit/mirrors-eslint)       |
+| [flake8](https://github.com/pycqa/flake8)                             | [hook](https://github.com/pre-commit/pre-commit-hooks)         | [isort](https://github.com/pycqa/isort)                               | [markdownlint](https://github.com/markdownlint/markdownlint) |
+| [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) | [mypy](https://github.com/pre-commit/mirrors-mypy)             | [no-commit-to-branch](https://github.com/pre-commit/pre-commit-hooks) | [prettier](https://github.com/pre-commit/mirrors-prettier)   |
+| [pygrep-hooks](https://github.com/pre-commit/pygrep-hooks)            | [pyupgrade](https://github.com/asottile/pyupgrade)             | [ruff](https://github.com/astral-sh/ruff-pre-commit)                  | [shellcheck](https://github.com/shellcheck-py/shellcheck-py) |
+| [yamllint](https://github.com/adrienverge/yamllint.git)               |                                                                |                                                                       |                                                              |
+
 <!-- markdownlint-enable MD013 -->
 
 To use a snippet, simply start typing the name of the hook in your

--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -176,13 +176,25 @@
       "      - id: ruff",
       "        language_version: ${2|python3.10,python3.8,python3.9,python3.11,python3.12|}",
       "        args: ${3:[]}",
-      "        types_or: ${4:[ python, pyi, jupyter ]}",
+      "        types_or: ${4:[ python, pyi, jupyter ]}"
+    ],
+    "description": "Code snippet for \"ruff\" in pre-commit."
+  },
+
+  "ruff-format": {
+    "scope": "yaml",
+    "prefix": "pre-commit-ruff-format",
+    "body": [
+      "  - repo: https://github.com/astral-sh/ruff-pre-commit",
+      "    rev: ${1:\"\"}",
+      "    hooks:",
       "      - id: ruff-format",
       "        language_version: ${2|python3.10,python3.8,python3.9,python3.11,python3.12|}",
-      "        args: ${5:[]}"
+      "        args: ${3:[]}"
     ],
-    "description": "Code snippet for \"ruff\" and \"ruff-format\" in pre-commit."
+    "description": "Code snippet for \"ruff-format\" in pre-commit."
   },
+
   "flake8": {
     "scope": "yaml",
     "prefix": "pre-commit-flake8",
@@ -298,38 +310,38 @@
     ],
     "description": "Code snippet for \"ansible-lint\" in pre-commit."
   },
-    "yamllint": {
-        "scope": "yaml",
-        "prefix": "pre-commit-yamllint",
-        "body": [
-            "  - repo: https://github.com/adrienverge/yamllint.git",
-            "    rev: ${1:\"\"}",
-            "    hooks:",
-            "      - id: yamllint",
-            "        files: \\.(${2|yaml,yml,yml\\|yaml|})$",
-            "        types: [file, yaml]",
-            "        entry: yamllint --strict",
-            "        language_version: ${3|python3.10,python3.8,python3.9,python3.11,python3.12|}"
-        ],
-        "description": "Code snippet for \"yamllint\" in pre-commit."
-    },
-      "codespell": {
-        "scope": "yaml",
-        "prefix": "pre-commit-codespell",
-        "body": [
-          "  - repo: https://github.com/codespell-project/codespell",
-          "    rev: ${1:\"\"}",
-          "    hooks:",
-          "      - id: codespell",
-          "        exclude: >-",
-          "          (?x)^(",
-          "            .vscode/.*|",
-          "            .github/.*|",
-          "          )$",
-          "        args: ${2:[-w, --ignore-words-list=${3:ignore-words.txt}]}",
-          "        language_version: ${4|python3.10,python3.8,python3.9,python3.11,python3.12|}",
-          "        additional_dependencies: ${5:[tomli]}"
-        ],
-        "description": "Code snippet for \"codespell\" in pre-commit."
-      }
-    }
+  "yamllint": {
+    "scope": "yaml",
+    "prefix": "pre-commit-yamllint",
+    "body": [
+      "  - repo: https://github.com/adrienverge/yamllint.git",
+      "    rev: ${1:\"\"}",
+      "    hooks:",
+      "      - id: yamllint",
+      "        files: \\.(${2|yaml,yml,yml\\|yaml|})$",
+      "        types: [file, yaml]",
+      "        entry: yamllint --strict",
+      "        language_version: ${3|python3.10,python3.8,python3.9,python3.11,python3.12|}"
+    ],
+    "description": "Code snippet for \"yamllint\" in pre-commit."
+  },
+  "codespell": {
+    "scope": "yaml",
+    "prefix": "pre-commit-codespell",
+    "body": [
+      "  - repo: https://github.com/codespell-project/codespell",
+      "    rev: ${1:\"\"}",
+      "    hooks:",
+      "      - id: codespell",
+      "        exclude: >-",
+      "          (?x)^(",
+      "            .vscode/.*|",
+      "            .github/.*|",
+      "          )$",
+      "        args: ${2:[-w, --ignore-words-list=${3:ignore-words.txt}]}",
+      "        language_version: ${4|python3.10,python3.8,python3.9,python3.11,python3.12|}",
+      "        additional_dependencies: ${5:[tomli]}"
+    ],
+    "description": "Code snippet for \"codespell\" in pre-commit."
+  }
+}


### PR DESCRIPTION
This pull request adds the "ruff-format" hook to the pre-commit configuration. The "ruff-format" hook is responsible for formatting YAML files using the Ruff formatter. This will help ensure consistent code style and improve code readability.